### PR TITLE
Reduce initial HERTZ asset amplitude for improved stability

### DIFF
--- a/bts_tools/feeds.py
+++ b/bts_tools/feeds.py
@@ -415,8 +415,8 @@ def get_feed_prices(node):
     if 'HERTZ' not in get_disabled_assets():
         hertz_reference_timestamp = "2015-10-13T14:12:24+00:00" # Bitshares 2.0 genesis block timestamp
         hertz_current_timestamp = pendulum.now().timestamp() # Current timestamp for reference within the hertz script
-        hertz_amplitude = 1/3 # 33.33..% fluctuation
-        hertz_period_days = 28 # 30.43 days converted to an UNIX timestamp // TODO: Potentially change this value to 28
+        hertz_amplitude = 0.14 # 14% fluctuation (1% per day)
+        hertz_period_days = 28 # 28 days
         hertz_phase_days = 0.908056 # Time offset from genesis till the first wednesday, to set wednesday as the primary Hz day.
         hertz_reference_asset_price = usd_price
         


### PR DESCRIPTION
Going over the HERTZ asset variables, I believe that further reducing the amplitude would be wise.

At 1/3 amplitude, shorting at the bottom yields a 66% debt appreciation in a matter of two weeks (4.74%/day) which is quite high and may result in a lack of shorters at the bottom (preventing peak shorters from realizing gains).

At 14% (0.14) amplitude and a period of 28 days, the price feed changes at a rate of 1% per day which is more appropriate for an initial implementation of HERTZ. Subsequent HERTZ ABA implementations could explore increased amplitudes.

Apologies for the multiple pull requests, last time for this ABA I promise ;D